### PR TITLE
Multi address family support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 
 [dependencies]
 byteorder  = "0.5"
-eventual   = "0.1"
 libc       = "0.2"
 log        = "0.3"
 mio        = "0.5"

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -53,7 +53,11 @@ pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
 
 #[derive(Clone)]
 pub enum Command {
-    SendUnsolicited(ServiceData, u32, bool),
+    SendUnsolicited {
+        svc: ServiceData,
+        ttl: u32,
+        include_ip: bool
+    },
     Shutdown,
 }
 
@@ -267,7 +271,7 @@ impl rotor::Machine for FSM {
                     scope.shutdown_loop();
                     return rotor::Response::done();
                 }
-                Ok(Command::SendUnsolicited(svc, ttl, include_ip)) => {
+                Ok(Command::SendUnsolicited { svc, ttl, include_ip }) => {
                     match self.send_unsolicited(&svc, ttl, include_ip) {
                         Ok(_) => (),
                         Err(e) => {

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -170,23 +170,23 @@ impl FSM {
         match question.qtype {
             QueryType::A |
             QueryType::AAAA |
-            QueryType::All if question.qname == services.hostname => {
-                builder = self.add_ip_rr(&services.hostname, builder, DEFAULT_TTL);
+            QueryType::All if question.qname == *services.get_hostname() => {
+                builder = self.add_ip_rr(services.get_hostname(), builder, DEFAULT_TTL);
             }
             QueryType::PTR => {
                 for id in services.by_type.get_vec(&question.qname).unwrap_or(&vec![]) {
                     let svc = services.by_id.get(id).expect("missing service");
                     builder = svc.add_ptr_rr(builder, DEFAULT_TTL);
-                    builder = svc.add_srv_rr(&services.hostname, builder, DEFAULT_TTL);
+                    builder = svc.add_srv_rr(services.get_hostname(), builder, DEFAULT_TTL);
                     builder = svc.add_txt_rr(builder, DEFAULT_TTL);
-                    builder = self.add_ip_rr(&services.hostname, builder, DEFAULT_TTL);
+                    builder = self.add_ip_rr(services.get_hostname(), builder, DEFAULT_TTL);
                 }
             }
             QueryType::SRV => {
                 if let Some(id) = services.by_name.get(&question.qname) {
                     let svc = services.by_id.get(id).expect("missing service");
-                    builder = svc.add_srv_rr(&services.hostname, builder, DEFAULT_TTL);
-                    builder = self.add_ip_rr(&services.hostname, builder, DEFAULT_TTL);
+                    builder = svc.add_srv_rr(services.get_hostname(), builder, DEFAULT_TTL);
+                    builder = self.add_ip_rr(services.get_hostname(), builder, DEFAULT_TTL);
                 }
             }
             QueryType::TXT => {
@@ -228,10 +228,10 @@ impl FSM {
         let services = self.services.read().unwrap();
 
         builder = svc.add_ptr_rr(builder, ttl);
-        builder = svc.add_srv_rr(&services.hostname, builder, ttl);
+        builder = svc.add_srv_rr(services.get_hostname(), builder, ttl);
         builder = svc.add_txt_rr(builder, ttl);
         if include_ip {
-            builder = self.add_ip_rr(&services.hostname, builder, ttl);
+            builder = self.add_ip_rr(services.get_hostname(), builder, ttl);
         }
 
         if !builder.is_empty() {

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -174,8 +174,7 @@ impl FSM {
                 builder = self.add_ip_rr(services.get_hostname(), builder, DEFAULT_TTL);
             }
             QueryType::PTR => {
-                for id in services.by_type.get_vec(&question.qname).unwrap_or(&vec![]) {
-                    let svc = services.by_id.get(id).expect("missing service");
+                for svc in services.find_by_type(&question.qname) {
                     builder = svc.add_ptr_rr(builder, DEFAULT_TTL);
                     builder = svc.add_srv_rr(services.get_hostname(), builder, DEFAULT_TTL);
                     builder = svc.add_txt_rr(builder, DEFAULT_TTL);
@@ -183,15 +182,13 @@ impl FSM {
                 }
             }
             QueryType::SRV => {
-                if let Some(id) = services.by_name.get(&question.qname) {
-                    let svc = services.by_id.get(id).expect("missing service");
+                if let Some(svc) = services.find_by_name(&question.qname) {
                     builder = svc.add_srv_rr(services.get_hostname(), builder, DEFAULT_TTL);
                     builder = self.add_ip_rr(services.get_hostname(), builder, DEFAULT_TTL);
                 }
             }
             QueryType::TXT => {
-                if let Some(id) = services.by_name.get(&question.qname) {
-                    let svc = services.by_id.get(id).expect("missing service");
+                if let Some(svc) = services.find_by_name(&question.qname) {
                     builder = svc.add_txt_rr(builder, DEFAULT_TTL);
                 }
             }

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -165,7 +165,7 @@ impl FSM {
     }
 
     fn handle_question(&self, question: &dns_parser::Question, mut builder: AnswerBuilder) -> AnswerBuilder {
-        let services = self.services.lock().unwrap();
+        let services = self.services.read().unwrap();
 
         match question.qtype {
             QueryType::A |
@@ -225,7 +225,7 @@ impl FSM {
         let mut builder = dns_parser::Builder::new_response(0, false).move_to::<dns_parser::Answers>();
         builder.set_max_size(None);
 
-        let services = self.services.lock().unwrap();
+        let services = self.services.read().unwrap();
 
         builder = svc.add_ptr_rr(builder, ttl);
         builder = svc.add_srv_rr(&services.hostname, builder, ttl);

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -8,7 +8,7 @@ use std::io;
 use std::io::ErrorKind::Interrupted;
 use std::sync::mpsc::{channel, Sender, Receiver, TryRecvError};
 use net;
-use services::{SharedServices, ServiceData};
+use services::{Services, ServiceData};
 
 const MDNS_PORT : u16 = 5353;
 
@@ -66,11 +66,11 @@ pub struct FSM {
     af: AddressFamily,
     socket: UdpSocket,
     rx: Receiver<Command>,
-    services: SharedServices,
+    services: Services,
 }
 
 impl FSM {
-    pub fn new(af: AddressFamily, services: &SharedServices) -> io::Result<(FSM, Sender<Command>)> {
+    pub fn new(af: AddressFamily, services: &Services) -> io::Result<(FSM, Sender<Command>)> {
         let socket = try!(af.udp_socket());
 
         net::set_reuse_addr(&socket, true);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,11 @@ impl Responder {
     }
 
     fn send_unsolicited(&self, svc: ServiceData, ttl: u32, include_ip: bool) {
-        self.send(Command::SendUnsolicited(svc, ttl, include_ip));
+        self.send(Command::SendUnsolicited {
+            svc: svc,
+            ttl: ttl,
+            include_ip: include_ip,
+        });
     }
 
     fn send(&self, cmd: Command) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod fsm;
 use fsm::{AddressFamily, FSM, Command, DEFAULT_TTL};
 
 mod services;
-use services::{Services, SharedServices, ServiceData};
+use services::{ServicesInner, Services, ServiceData};
 mod net;
 
 use std::sync::mpsc::Sender;
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex, RwLock};
 
 pub struct Responder {
     handle: Option<thread::JoinHandle<()>>,
-    services: SharedServices,
+    services: Services,
     txs_notifiers: Vec<(Sender<Command>, rotor::Notifier)>,
 }
 
@@ -41,7 +41,7 @@ impl Responder {
         if !hostname.ends_with(".local") {
             hostname.push_str(".local");
         }
-        let services = Arc::new(RwLock::new(Services::new(hostname)));
+        let services = Arc::new(RwLock::new(ServicesInner::new(hostname)));
 
         let mut config = rotor::Config::new();
         config.slab_capacity(32);

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::collections::HashMap;
 use multimap::MultiMap;
 use rand::{Rng, thread_rng};
@@ -7,7 +7,7 @@ use dns_parser::{self, QueryClass, Name, RRData};
 pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
 
 
-pub type SharedServices = Arc<Mutex<Services>>;
+pub type SharedServices = Arc<RwLock<Services>>;
 
 pub struct Services {
     pub hostname: Name<'static>,

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,0 +1,93 @@
+use std::sync::{Arc, Mutex};
+use std::collections::HashMap;
+use multimap::MultiMap;
+use rand::{Rng, thread_rng};
+use dns_parser::{self, QueryClass, Name, RRData};
+
+pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
+
+
+pub type SharedServices = Arc<Mutex<Services>>;
+
+pub struct Services {
+    pub hostname: Name<'static>,
+    /// main index
+    pub by_id: HashMap<usize, ServiceData>,
+    /// maps to id
+    pub by_type: MultiMap<Name<'static>, usize>,
+    /// maps to id
+    pub by_name: HashMap<Name<'static>, usize>
+}
+
+impl Services {
+    pub fn new(hostname: String) -> Self {
+        Services {
+            hostname: Name::from_str(hostname).unwrap(),
+            by_id: HashMap::new(),
+            by_type: MultiMap::new(),
+            by_name: HashMap::new(),
+        }
+    }
+
+    pub fn register(&mut self, svc: ServiceData) -> usize {
+        let mut id = thread_rng().gen::<usize>();
+        while self.by_id.contains_key(&id) {
+            id = thread_rng().gen::<usize>();
+        }
+
+        self.by_type.insert(svc.typ.clone(), id);
+        self.by_name.insert(svc.name.clone(), id);
+        self.by_id.insert(id, svc);
+
+        id
+    }
+
+    pub fn unregister(&mut self, id: usize) -> ServiceData {
+        use std::collections::hash_map::Entry;
+
+        let svc = self.by_id.remove(&id).expect("unknown service");
+
+        if let Some(entries) = self.by_type.get_vec_mut(&svc.typ) {
+            entries.retain(|&e| e == id);
+        }
+
+        match self.by_name.entry(svc.name.clone()) {
+            Entry::Occupied(entry) => {
+                assert_eq!(*entry.get(), id);
+                entry.remove();
+            }
+            _ => {
+                panic!("unknown/wrong service for id {}", id);
+            }
+        }
+
+        svc
+    }
+}
+
+#[derive(Clone)]
+pub struct ServiceData {
+    pub name: Name<'static>,
+    pub typ: Name<'static>,
+    pub port: u16,
+    pub txt: Vec<u8>,
+}
+
+impl ServiceData {
+    pub fn add_ptr_rr(&self, builder: AnswerBuilder, ttl: u32) -> AnswerBuilder {
+        builder.add_answer(&self.typ, QueryClass::IN, ttl, &RRData::PTR(self.name.clone()))
+    }
+
+    pub fn add_srv_rr(&self, hostname: &Name, builder: AnswerBuilder, ttl: u32) -> AnswerBuilder {
+        builder.add_answer(&self.name, QueryClass::IN, ttl, &RRData::SRV {
+            priority: 0,
+            weight: 0,
+            port: self.port,
+            target: hostname.clone(),
+        })
+    }
+
+    pub fn add_txt_rr(&self, builder: AnswerBuilder, ttl: u32) -> AnswerBuilder {
+        builder.add_answer(&self.name, QueryClass::IN, ttl, &RRData::TXT(&self.txt))
+    }
+}

--- a/src/services.rs
+++ b/src/services.rs
@@ -10,7 +10,7 @@ pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
 pub type Services = Arc<RwLock<ServicesInner>>;
 
 pub struct ServicesInner {
-    pub hostname: Name<'static>,
+    hostname: Name<'static>,
     /// main index
     pub by_id: HashMap<usize, ServiceData>,
     /// maps to id
@@ -27,6 +27,10 @@ impl ServicesInner {
             by_type: MultiMap::new(),
             by_name: HashMap::new(),
         }
+    }
+
+    pub fn get_hostname(&self) -> &Name<'static> {
+        &self.hostname
     }
 
     pub fn register(&mut self, svc: ServiceData) -> usize {

--- a/src/services.rs
+++ b/src/services.rs
@@ -7,9 +7,9 @@ use dns_parser::{self, QueryClass, Name, RRData};
 pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
 
 
-pub type SharedServices = Arc<RwLock<Services>>;
+pub type Services = Arc<RwLock<ServicesInner>>;
 
-pub struct Services {
+pub struct ServicesInner {
     pub hostname: Name<'static>,
     /// main index
     pub by_id: HashMap<usize, ServiceData>,
@@ -19,9 +19,9 @@ pub struct Services {
     pub by_name: HashMap<Name<'static>, usize>
 }
 
-impl Services {
+impl ServicesInner {
     pub fn new(hostname: String) -> Self {
-        Services {
+        ServicesInner {
             hostname: Name::from_str(hostname).unwrap(),
             by_id: HashMap::new(),
             by_type: MultiMap::new(),

--- a/src/services.rs
+++ b/src/services.rs
@@ -7,6 +7,7 @@ use dns_parser::{self, QueryClass, Name, RRData};
 pub type AnswerBuilder = dns_parser::Builder<dns_parser::Answers>;
 
 
+/// A collection of registered services is shared between threads.
 pub type Services = Arc<RwLock<ServicesInner>>;
 
 pub struct ServicesInner {
@@ -84,6 +85,7 @@ impl ServicesInner {
     }
 }
 
+/// Returned by [`ServicesInner.find_by_type`](struct.ServicesInner.html#method.find_by_type)
 pub struct FindByType<'a> {
     services: &'a ServicesInner,
     ids: &'a [usize],
@@ -112,6 +114,7 @@ pub struct ServiceData {
     pub txt: Vec<u8>,
 }
 
+/// Packet building helpers for `fsm` to respond with `ServiceData`
 impl ServiceData {
     pub fn add_ptr_rr(&self, builder: AnswerBuilder, ttl: u32) -> AnswerBuilder {
         builder.add_answer(&self.typ, QueryClass::IN, ttl, &RRData::PTR(self.name.clone()))


### PR DESCRIPTION
I know the changes are huge but give it some consideration...

Would it make sense to filter `iface.ip()` for the address family of the socket that received a query?
