### PR TITLE
Drop incorrectly unregistered a service after it is cloned

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,12 +134,3 @@ impl Drop for Responder {
         self.handle.take().map(|h| h.join());
     }
 }
-
-impl <'a> Drop for Service<'a> {
-    fn drop(&mut self) {
-        let svc = self.responder.services
-            .write().unwrap()
-            .unregister(self.id);
-        self.responder.send_unsolicited(svc, 0, false);
-    }
-}


### PR DESCRIPTION
in [lib.rs:103](https://github.com/plietar/rust-mdns/blob/master/src/lib.rs#L103) a Service is cloned. This clone is Dropped after sending the command to the thread which causes the service to be unregistered. Because of that, the responder never responds to queries

You should probably deregister on Drop of Responder, but I couldn't get it easily to work and gave up for now
