### PR TITLE
Update nix version to build on mipsel.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 log = "0.3"
 multimap = "0.3"
 net2 = "0.2"
-nix = "0.7"
+nix = "0.8"
 rand = "0.3"
 tokio-core = "0.1.1"
 


### PR DESCRIPTION
The 0.8 version of nix contains a few fixes that are required for mipsel targets.

Please note that this will probably require updating the Cargo.lock file of depending crates (such as librespot) as things like libc might have changed.