### PR TITLE
Handle errors in Responder

### DIFF
--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -69,7 +69,7 @@ impl <AF: AddressFamily> FSM<AF> {
 
             self.handle_packet(&buf[..bytes], addr);
         }
-        return Ok(())
+        Ok(())
     }
 
     fn handle_packet(&mut self, buffer: &[u8], addr: SocketAddr) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ impl Responder {
                 match Self::setup_core() {
                     Ok((mut core, task, responder)) => {
                         tx.send(Ok(responder)).expect("tx responder channel closed");
-                        core.run(task).expect("mdsn thread failed");
+                        core.run(task).expect("mdns thread failed");
                     }
                     Err(err) => {
                         tx.send(Err(err)).expect("tx responder channel closed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,16 +58,16 @@ impl Responder {
             .spawn(move || {
                 match Self::setup_core() {
                     Ok((mut core, task, responder)) => {
-                        tx.send(Ok(responder)).expect("Could not write Ok to sync_channel");
-                        core.run(task).expect("Could not run task");
+                        tx.send(Ok(responder)).expect("tx responder channel closed");
+                        core.run(task).expect("mdsn thread failed");
                     }
                     Err(err) => {
-                        tx.send(Err(err)).expect("Could not write Error to sync_channel");
+                        tx.send(Err(err)).expect("tx responder channel closed");
                     }
                 }
             })?;
 
-        rx.recv().expect("Could not receive from sync_channel")
+        rx.recv().expect("rx responder channel closed")
     }
 
     pub fn spawn(handle: &Handle) -> io::Result<Responder> {

--- a/src/net.rs
+++ b/src/net.rs
@@ -40,7 +40,7 @@ impl Iterator for GetIfAddrs {
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.1.is_null() {
-            return None
+            None
         } else {
             unsafe {
                 let iface = Interface::new(&*self.1);


### PR DESCRIPTION
I had panics when using rust-mdns at boot of a raspberry pi. This was resolved by replacing the unwraps in `setup_core` with `?`. I can now handle the Error in your application instead of a panic.

Added `expect()` instead of `unwrap` in the responder thread to print out some context if the responder thread panics