### PR TITLE
Rename project to mdns_responder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mdns"
+name = "mdns-responder"
 version = "0.2.0"
 authors = ["Paul Lietar <paul@lietar.net>"]
 
@@ -18,7 +18,6 @@ net2 = "0.2"
 nix = "0.8"
 rand = "0.3"
 tokio-core = "0.1.1"
-
 dns-parser = { git = "https://github.com/plietar/dns-parser" }
 
 [target.'cfg(windows)'.dependencies]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ rust-mdns is a pure rust implementation of the mDNS ([RFC 6762]) and DNS-SD ([RF
 To use it, first add this to your `Cargo.toml`:
 
 ```toml
-[dependencies.mdns]
-git = "https://github.com/plietar/rust-mdns"
+[dependencies.mdns-responder]
+git = "https://github.com/EternalDeiwos/rust-mdns"
 ```
 
 Then, add this to your crate root:
 
 ```rust
-extern crate mdns;
+extern crate mdns_responder;
 ```
 
 [RFC 6762]: https://tools.ietf.org/html/rfc6762

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# rust-mdns - Rust mDNS responder
+# mdns_responder - Rust mDNS responder
 
-rust-mdns is a pure rust implementation of the mDNS ([RFC 6762]) and DNS-SD ([RFC 6763]) protocols.
+mdns_responder is a pure rust implementation of the mDNS ([RFC 6762]) and DNS-SD ([RFC 6763]) protocols.
 
 ## Usage
 
@@ -8,7 +8,7 @@ To use it, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies.mdns-responder]
-git = "https://github.com/EternalDeiwos/rust-mdns"
+git = "https://github.com/plietar/rust-mdns-responder"
 ```
 
 Then, add this to your crate root:

--- a/examples/register.rs
+++ b/examples/register.rs
@@ -1,11 +1,11 @@
 extern crate env_logger;
-extern crate mdns;
+extern crate mdns_responder;
 extern crate dns_parser;
 
 pub fn main() {
     env_logger::init().unwrap();
 
-    let responder = mdns::Responder::new().unwrap();
+    let responder = mdns_responder::Responder::new().unwrap();
     let _svc = responder.register(
         "_http._tcp".to_owned(),
         "Web Server".to_owned(),


### PR DESCRIPTION
Unfortunately there's a namespace collision with [another mdns crate](https://crates.io/crates/mdns). Renaming would disambigue and help specify that this is an implementation of an mdns responder.