### PR TITLE
Bump kernel32-sys to 0.2.2 to fix compatibility with newer Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dns-parser = { git = "https://github.com/plietar/dns-parser" }
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.2.8"
-kernel32-sys = "0.1"
+kernel32-sys = "0.2.2"
 socket2 = "0.2.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Building rust-mdns on Windows using Rust 1.20 would end in 2MB of error messages caused by kernel32-sys. Bumping the version to 0.2.2 fixes this.

I was seeing issues using the Rust/MSVC toolchain. Eg. @sashahilton00 mentioned that he didn't experience this problem with the GNU toolchain. Go figure...