### PR TITLE
Make responses authoritative.

### DIFF
--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -94,9 +94,9 @@ impl<AF: AddressFamily> FSM<AF> {
             return;
         }
 
-        let mut unicast_builder = dns_parser::Builder::new_response(packet.header.id, false)
+        let mut unicast_builder = dns_parser::Builder::new_response(packet.header.id, false, true)
             .move_to::<dns_parser::Answers>();
-        let mut multicast_builder = dns_parser::Builder::new_response(packet.header.id, false)
+        let mut multicast_builder = dns_parser::Builder::new_response(packet.header.id, false, true)
             .move_to::<dns_parser::Answers>();
         unicast_builder.set_max_size(None);
         multicast_builder.set_max_size(None);
@@ -197,7 +197,7 @@ impl<AF: AddressFamily> FSM<AF> {
 
     fn send_unsolicited(&mut self, svc: &ServiceData, ttl: u32, include_ip: bool) {
         let mut builder =
-            dns_parser::Builder::new_response(0, false).move_to::<dns_parser::Answers>();
+            dns_parser::Builder::new_response(0, false, true).move_to::<dns_parser::Answers>();
         builder.set_max_size(None);
 
         let services = self.services.read().unwrap();


### PR DESCRIPTION
Section 18.4 of RFC6762 dictates that the AA bit MUST be set.

Corresponding dns-parser change: https://github.com/plietar/dns-parser/pull/3