### PR TITLE
bump nix to 0.11 for OpenBSD support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 log = "0.4"
 multimap = "0.4"
 net2 = "0.2"
-nix = "0.10"
+nix = "0.11"
 rand = "0.5"
 tokio-core = "0.1"
 


### PR DESCRIPTION
This fixes the mdns package on OpenBSD. Everything seems to build fine, but I don't have extensive testing. :D
 
This is part of my effort to make spotifyd work on OpenBSD: https://github.com/Spotifyd/spotifyd/issues/147