### PR TITLE
 Bump nix to fix arm compilation issues caused by `PTRACE_*` being removed 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 log = "0.4"
 multimap = "0.4"
 net2 = "0.2"
-nix = "0.11"
+nix = "0.14.1"
 rand = "0.5"
 tokio-core = "0.1"
 


### PR DESCRIPTION
`PTRACE_GETFPXREGS` and `PTRACE_SETFPXREGS` were removed in https://github.com/rust-lang/libc/commit/d2695436ba5072078796c76f727a296e0f43caa6 and thus `nix` was failing to compile for arm targets if some other crate depended on `libc: ^0.2.55` and above. 

The fix for `nix` (https://github.com/nix-rust/nix/commit/196b05b5c7be39b73dcadca5457948d807fdf913) was backported but only down to ~`0.13`~ `0.11`  (https://github.com/nix-rust/nix/issues/1057) 

EDIT: I just saw scrolled down a bit more and saw that it was also backported to `0.11.1` making this PR unnecessary..